### PR TITLE
Use fastavro for parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.2.0 (UNRELEASED)
+
+### Added
+
+- `typed_dict_from_schema_file(schema_path)`
+
+### Breaking Changes
+
+- `schema_to_typed_dict` is now `typed_dict_from_schema_string`
+- Types are now prepended by their namespace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,29 @@ Currently, it supports converting `record`s to `TypedDict`. If you would like to
 
 ## Why would I want this?
 
-This library is target to people writing code generation for python apps that are using avro.
+This library is targeted to people writing code generation for python apps that are using avro.
 
-## Example usage
+## Usage
 
-If you are using Avro (with our without Schema Registry) you will want to to have some type safety when you messages are deserialized.
+This library does one thing, it converts Avro schemas to python types.
 
-[This example project](/examples/sync_types) shows how to keep a directory of Avro schemas in sync with a directory of python files exposing their types.
+To get up and running quickly, you can use this to simply load schemas and print out the python
+code that is generated.
+
+```python
+import glob
+from avro_to_python_types import typed_dict_from_schema_file
+
+schema_files = glob.glob("schemas/*.avsc")
+
+for schema_file in schema_files:
+    types = typed_dict_from_schema_file(schema_file)
+    print(types)
+
+```
+
+For a real world example of syncing a directory of schemas into a directory of matching python typed dictionaries
+check out the example app [here](/examples/sync_types)
 
 To try it out, simply clone this repo and run
 
@@ -20,11 +36,25 @@ To try it out, simply clone this repo and run
 
 `poetry run sync-example`
 
-For example, this avro schema will produce the following python
+For some more advanced examples, like referencing other schema files by their full name take a look at the tests [here](/tests)
+
+### Referencing schemas
+
+This library supports referencing schemas in different files by their fullname.
+
+In order for this behaviour to work, all schemas must be in the same directory and use the following naming convention: `namespace.name.avsc`. Note that is the same as `fullname.avsc`
+
+For more on this checkout the docs for fastavro [here](https://fastavro.readthedocs.io/en/latest/schema.html#fastavro._schema_py.load_schema).
+
+An example of this can be found in the tests.
+
+## Example output
+
+The following example shows the type generated for a given schema.
 
 ```json
 {
-  "namespace": "example.avro",
+  "namespace": "example",
   "type": "record",
   "name": "User",
   "fields": [
@@ -60,17 +90,17 @@ For example, this avro schema will produce the following python
 ```python
 from typing import TypedDict, Optional
 
-class AddressUSRecord(TypedDict):
+class example_AddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class OtherThing(TypedDict):
+class example_OtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class User(TypedDict):
+class example_User(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Currently, it supports converting `record`s to `TypedDict`. If you would like to
 
 ## Why would I want this?
 
-This library is targeted to people writing code generation for python apps that are using avro.
+This library is targeted to people writing code generation for python apps that are using [avro](https://avro.apache.org/docs/current/spec.html).
 
 ## Usage
 
-This library does one thing, it converts Avro schemas to python types.
+This library does [one thing](https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well), it converts Avro schemas to python types.
 
 To get up and running quickly, you can use this to simply load schemas and print out the python
 code that is generated.

--- a/avro_to_python_types/__init__.py
+++ b/avro_to_python_types/__init__.py
@@ -1,2 +1,5 @@
 __version__ = "0.1.0"
-from .schema_to_typed_dict import schema_to_typed_dict
+from .typed_dict_from_schema import (
+    typed_dict_from_schema_file,
+    typed_dict_from_schema_string,
+)

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -20,6 +20,14 @@ def is_nested(field):
 
 
 def dedupe_ast(tree):
+    """Takes an AST that has multiple identical classes defined and dedupes them."""
+    ###
+    # As an intermediate step in the typegen process we fully expand the schema, this will
+    # result in all referenced types being defined with their namespace - even if the same()
+    # one is defines more than once. This is of course not valid, and we want to dedupe it.
+    # https://fastavro.readthedocs.io/en/latest/schema.html#fastavro._schema_py.expand_schema
+    ###
+
     all_types = tree.body
     existing_type_names = []
     deduped_types = []

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -1,5 +1,6 @@
 from .generate_typed_dict import GenerateTypedDict
 from .schema_mapping import prim_to_type
+from fastavro.schema import load_schema, expand_schema, parse_schema
 import ast
 import json
 import astor
@@ -18,13 +19,30 @@ def is_nested(field):
     return False
 
 
-def type_for_schema(schema):
+def dedupe_ast(tree):
+    all_types = tree.body
+    existing_type_names = []
+    deduped_types = []
+    for current_type in all_types:
+        type_name = current_type.body[0].name
+        if type_name in existing_type_names:
+            continue
+        existing_type_names.append(type_name)
+        deduped_types.append(current_type)
+
+    tree.body = deduped_types
+    return tree
+
+
+def types_for_schema(schema):
+
     body = []
     tree = ast.Module(body)
     body = tree.body
 
     def type_for_schema_record(record_schema):
-        our_type = GenerateTypedDict(record_schema["name"])
+        type_name = record_schema["name"].replace(".", "_")
+        our_type = GenerateTypedDict(type_name)
         for field in record_schema["fields"]:
             name = field["name"]
             if is_nested(field):
@@ -45,11 +63,18 @@ def type_for_schema(schema):
 
     main_type = type_for_schema_record(schema)
     body.append(main_type.tree)
-    return tree
 
-
-def schema_to_typed_dict(test_schema):
-    new_type = type_for_schema(json.loads(test_schema))
     imports = "from typing import TypedDict, Optional\n\n"
-    types = astor.to_source(new_type)
+    types = astor.to_source(dedupe_ast(tree))
     return imports + types
+
+
+def typed_dict_from_schema_string(schema_string):
+    schema = parse_schema(json.loads(schema_string))
+    return types_for_schema(schema)
+
+
+def typed_dict_from_schema_file(schema_path):
+    schema = expand_schema(load_schema(schema_path))
+
+    return types_for_schema(schema)

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -19,7 +19,7 @@ def is_nested(field):
     return False
 
 
-def dedupe_ast(tree):
+def _dedupe_ast(tree):
     """Takes an AST that has multiple identical classes defined and dedupes them."""
     ###
     # As an intermediate step in the typegen process we fully expand the schema, this will
@@ -73,7 +73,7 @@ def types_for_schema(schema):
     body.append(main_type.tree)
 
     imports = "from typing import TypedDict, Optional\n\n"
-    types = astor.to_source(dedupe_ast(tree))
+    types = astor.to_source(_dedupe_ast(tree))
     return imports + types
 
 

--- a/examples/sync_types/sync_types.py
+++ b/examples/sync_types/sync_types.py
@@ -1,6 +1,6 @@
 import glob
 import os
-from avro_to_python_types import typed_dict_from_schema
+from avro_to_python_types import typed_dict_from_schema_file
 
 current_directory = f"{os.getcwd()}/examples/sync_types"
 schema_file_paths = glob.glob(f"{current_directory}/schemas/*.avsc")
@@ -15,11 +15,8 @@ def schema_name_from_path(path):
 
 def generate_types_from_schemas():
     for schema_file_path in schema_file_paths:
-        with open(schema_file_path) as f:
-            avro_schema = f.read()
-        python_contents = typed_dict_from_schema(avro_schema)
+        python_contents = typed_dict_from_schema_file(schema_file_path)
         schema_name = schema_name_from_path(schema_file_path)
         type_file_name = f"{types_directory}/{schema_name}.py"
-        print(type_file_name)
         with open(type_file_name, "w+") as f:
             f.write(python_contents)

--- a/examples/sync_types/sync_types.py
+++ b/examples/sync_types/sync_types.py
@@ -1,6 +1,6 @@
 import glob
 import os
-from avro_to_python_types import schema_to_typed_dict
+from avro_to_python_types import typed_dict_from_schema
 
 current_directory = f"{os.getcwd()}/examples/sync_types"
 schema_file_paths = glob.glob(f"{current_directory}/schemas/*.avsc")
@@ -17,7 +17,7 @@ def generate_types_from_schemas():
     for schema_file_path in schema_file_paths:
         with open(schema_file_path) as f:
             avro_schema = f.read()
-        python_contents = schema_to_typed_dict(avro_schema)
+        python_contents = typed_dict_from_schema(avro_schema)
         schema_name = schema_name_from_path(schema_file_path)
         type_file_name = f"{types_directory}/{schema_name}.py"
         print(type_file_name)

--- a/examples/sync_types/types/nested_record.py
+++ b/examples/sync_types/types/nested_record.py
@@ -1,13 +1,13 @@
 from typing import TypedDict, Optional
 
 
-class AddressUSRecord(TypedDict):
+class example_avro_AddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class User(TypedDict):
+class example_avro_User(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: AddressUSRecord
+    address: example_avro_AddressUSRecord

--- a/examples/sync_types/types/nested_records.py
+++ b/examples/sync_types/types/nested_records.py
@@ -1,19 +1,19 @@
 from typing import TypedDict, Optional
 
 
-class AddressUSRecord(TypedDict):
+class example_avro_AddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class OtherThing(TypedDict):
+class example_avro_OtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class User(TypedDict):
+class example_avro_User(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: AddressUSRecord
-    other_thing: OtherThing
+    address: example_avro_AddressUSRecord
+    other_thing: example_avro_OtherThing

--- a/examples/sync_types/types/nested_records_deep.py
+++ b/examples/sync_types/types/nested_records_deep.py
@@ -1,24 +1,24 @@
 from typing import TypedDict, Optional
 
 
-class AddressUSRecord(TypedDict):
+class example_avro_AddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class NextOtherThing(TypedDict):
+class example_avro_NextOtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class OtherThing(TypedDict):
+class example_avro_OtherThing(TypedDict):
     thing1: str
-    other_thing: NextOtherThing
+    other_thing: example_avro_NextOtherThing
 
 
-class User(TypedDict):
+class example_avro_User(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: AddressUSRecord
-    other_thing: OtherThing
+    address: example_avro_AddressUSRecord
+    other_thing: example_avro_OtherThing

--- a/poetry.lock
+++ b/poetry.lock
@@ -75,6 +75,20 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "fastavro"
+version = "1.3.0"
+description = "Fast read/write of AVRO files"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+codecs = ["python-snappy", "zstandard", "lz4"]
+lz4 = ["lz4"]
+snappy = ["python-snappy"]
+zstandard = ["zstandard"]
+
+[[package]]
 name = "fastdiff"
 version = "0.2.0"
 description = "A fast native implementation of diff algorithm with a pure python fallback"
@@ -254,7 +268,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "cc7430ca65a879627501541baf06fd4bd9359b6eec867518c26729222b0b1cbd"
+content-hash = "1096d4e305007a0385a0c6b3fe7729dd0cf960a5983aae2c93b397dd28053cdc"
 
 [metadata.files]
 appdirs = [
@@ -283,6 +297,23 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+fastavro = [
+    {file = "fastavro-1.3.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:62ab5bc64dd12e7792ab9585429f3c3a34a5c7ca63846d79de7afe565dcc2c84"},
+    {file = "fastavro-1.3.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:e3d98c9f0a5f2217f9571712e855d42dd0de6dea4fed1e489f43098e4f84d163"},
+    {file = "fastavro-1.3.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:1c85781543032c17b9c28a1b87835900b36e21b3693509edcf9ca806ab575bfe"},
+    {file = "fastavro-1.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f2c600140e25ee36c1fd58d49601ca577c19b4f8b056f87b1d5ba19b346e2804"},
+    {file = "fastavro-1.3.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:0ba301ee8098cd6657eae67837d21bc47739e291dfc973e396a00190991d069b"},
+    {file = "fastavro-1.3.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:f4e2739f5277a14bd1efdd323d12e126d5fbb7f70e46c8f626bfbe79324b78e3"},
+    {file = "fastavro-1.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e71c099e9f8b57cb4f5e6d51c2f463f181f39a14a4a1024d99e373ee403bac8d"},
+    {file = "fastavro-1.3.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:ba0987332ac3dd928586e1afc5b5c82808a68e8036a51dbc4307edee50f992a8"},
+    {file = "fastavro-1.3.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2a4c2439182ac2f0d080e758dfe56ccfbb9af48da76fbf1ccb7a12deb6913a7b"},
+    {file = "fastavro-1.3.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:70a67fc8ba6e07c807d21c284a90962edf7e30ef02973961e7f49da11610a22d"},
+    {file = "fastavro-1.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:a84f39b45c767c444c35e4f40d811001f1fedd1418b92b0bf727486827476483"},
+    {file = "fastavro-1.3.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:f95b98dcc393aa76c353f2297545fd38e2c5d8361a58c553e272a1aea787e2c1"},
+    {file = "fastavro-1.3.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:4ea3399090de1d2e1212393d38be8c8c9da3725ed81dd6a2c0c1002d2b3eccca"},
+    {file = "fastavro-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:93305112901f990fcd21597af521f9499ccd2990f2b67f195d8e215a658717df"},
+    {file = "fastavro-1.3.0.tar.gz", hash = "sha256:f401be0ca4b1b17bda3ed69faaf967829ec8586cb6da6482b1f3bc9246a6fea6"},
 ]
 fastdiff = [
     {file = "fastdiff-0.2.0.tar.gz", hash = "sha256:623ad3d9055ab78e014d0d10767cb033d98d5d4f66052abf498350c8e42e29aa"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,26 @@ repository = "https://github.com/dangreenisrael/avro-to-python-types"
 license = "MIT"
 keywords = ["avro", "codegen", "avro schema", "typegen"]
 
+[tool.black]
+exclude = '''
+
+(
+  /(
+      \.eggs         
+    | \.git          
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | tests/snapshots
+)
+'''
+
 [tool.poetry.dependencies]
 python = "^3.9"
 astor = "^0.8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ keywords = ["avro", "codegen", "avro schema", "typegen"]
 [tool.poetry.dependencies]
 python = "^3.9"
 astor = "^0.8.1"
+fastavro = "^1.3.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/tests/snapshots/snap_test_schema_to_typed_dict.py
+++ b/tests/snapshots/snap_test_schema_to_typed_dict.py
@@ -7,67 +7,160 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots[
-    "SnapshotSchemaToTypedDict::test_snapshot_all_schemas nested_record.avsc"
-] = """from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildA.avsc'] = '''from typing import TypedDict, Optional
 
-class AddressUSRecord(TypedDict):
-    streetaddress: str
-    city: str
-
-
-class User(TypedDict):
+class common_ChildA(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: AddressUSRecord
-"""
+'''
 
-snapshots[
-    "SnapshotSchemaToTypedDict::test_snapshot_all_schemas nested_records.avsc"
-] = """from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildB.avsc'] = '''from typing import TypedDict, Optional
 
-class AddressUSRecord(TypedDict):
+class common_ChildB(TypedDict):
+    streetaddress: str
+    city: str
+'''
+
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas domain.Parent.avsc'] = '''from typing import TypedDict, Optional
+
+class common_ChildA(TypedDict):
+    name: str
+    favorite_number: Optional[int]
+    favorite_color: Optional[str]
+
+
+class common_ChildB(TypedDict):
     streetaddress: str
     city: str
 
 
-class OtherThing(TypedDict):
+class domain_CompositeItem(TypedDict):
+    composite_a: common_ChildA
+    composite_b: common_ChildB
+
+
+class domain_Parent(TypedDict):
+    first_item: common_ChildA
+    second_item: common_ChildA
+    composite_item: domain_CompositeItem
+    favorite_color: Optional[str]
+'''
+
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_record.avsc'] = '''from typing import TypedDict, Optional
+
+class example_avro_AddressUSRecord(TypedDict):
+    streetaddress: str
+    city: str
+
+
+class example_avro_User(TypedDict):
+    name: str
+    favorite_number: Optional[int]
+    favorite_color: Optional[str]
+    address: example_avro_AddressUSRecord
+'''
+
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records.avsc'] = '''from typing import TypedDict, Optional
+
+class example_AddressUSRecord(TypedDict):
+    streetaddress: str
+    city: str
+
+
+class example_OtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class User(TypedDict):
+class example_User(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: AddressUSRecord
-    other_thing: OtherThing
-"""
+    address: example_AddressUSRecord
+    other_thing: example_OtherThing
+'''
 
-snapshots[
-    "SnapshotSchemaToTypedDict::test_snapshot_all_schemas nested_records_deep.avsc"
-] = """from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records_deep.avsc'] = '''from typing import TypedDict, Optional
 
-class AddressUSRecord(TypedDict):
+class example_avro_AddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class NextOtherThing(TypedDict):
+class example_avro_NextOtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class OtherThing(TypedDict):
+class example_avro_OtherThing(TypedDict):
     thing1: str
-    other_thing: NextOtherThing
+    other_thing: example_avro_NextOtherThing
 
 
-class User(TypedDict):
+class example_avro_User(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: AddressUSRecord
-    other_thing: OtherThing
-"""
+    address: example_avro_AddressUSRecord
+    other_thing: example_avro_OtherThing
+'''
+
+snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_record.avsc'] = '''from typing import TypedDict, Optional
+
+class example_avro_AddressUSRecord(TypedDict):
+    streetaddress: str
+    city: str
+
+
+class example_avro_User(TypedDict):
+    name: str
+    favorite_number: Optional[int]
+    favorite_color: Optional[str]
+    address: example_avro_AddressUSRecord
+'''
+
+snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records.avsc'] = '''from typing import TypedDict, Optional
+
+class example_AddressUSRecord(TypedDict):
+    streetaddress: str
+    city: str
+
+
+class example_OtherThing(TypedDict):
+    thing1: str
+    thing2: Optional[int]
+
+
+class example_User(TypedDict):
+    name: str
+    favorite_number: Optional[int]
+    favorite_color: Optional[str]
+    address: example_AddressUSRecord
+    other_thing: example_OtherThing
+'''
+
+snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records_deep.avsc'] = '''from typing import TypedDict, Optional
+
+class example_avro_AddressUSRecord(TypedDict):
+    streetaddress: str
+    city: str
+
+
+class example_avro_NextOtherThing(TypedDict):
+    thing1: str
+    thing2: Optional[int]
+
+
+class example_avro_OtherThing(TypedDict):
+    thing1: str
+    other_thing: example_avro_NextOtherThing
+
+
+class example_avro_User(TypedDict):
+    name: str
+    favorite_number: Optional[int]
+    favorite_color: Optional[str]
+    address: example_avro_AddressUSRecord
+    other_thing: example_avro_OtherThing
+'''

--- a/tests/test_cases/nested_records.avsc
+++ b/tests/test_cases/nested_records.avsc
@@ -1,30 +1,51 @@
 {
-  "namespace": "example.avro",
+  "namespace": "example",
   "type": "record",
   "name": "User",
   "fields": [
-    { "name": "name", "type": "string" },
-    { "name": "favorite_number", "type": ["int", "null"] },
-    { "name": "favorite_color", "type": ["string", "null"] },
+    {
+      "name": "name",
+      "type": "string"
+    },
+    {
+      "name": "favorite_number",
+      "type": ["int", "null"]
+    },
+    {
+      "name": "favorite_color",
+      "type": ["string", "null"]
+    },
     {
       "name": "address",
       "type": {
         "type": "record",
         "name": "AddressUSRecord",
         "fields": [
-          { "name": "streetaddress", "type": "string" },
-          { "name": "city", "type": "string" }
+          {
+            "name": "streetaddress",
+            "type": "string"
+          },
+          {
+            "name": "city",
+            "type": "string"
+          }
         ]
       }
     },
-     {
+    {
       "name": "other_thing",
       "type": {
         "type": "record",
         "name": "OtherThing",
         "fields": [
-          { "name": "thing1", "type": "string" },
-          { "name": "thing2", "type": ["int", "null"] }
+          {
+            "name": "thing1",
+            "type": "string"
+          },
+          {
+            "name": "thing2",
+            "type": ["int", "null"]
+          }
         ]
       }
     }

--- a/tests/test_cases_expandable/common.ChildA.avsc
+++ b/tests/test_cases_expandable/common.ChildA.avsc
@@ -1,0 +1,10 @@
+{
+  "namespace": "common",
+  "type": "record",
+  "name": "ChildA",
+  "fields": [
+    { "name": "name", "type": "string" },
+    { "name": "favorite_number", "type": ["int", "null"] },
+    { "name": "favorite_color", "type": ["string", "null"] }
+  ]
+}

--- a/tests/test_cases_expandable/common.ChildB.avsc
+++ b/tests/test_cases_expandable/common.ChildB.avsc
@@ -1,0 +1,9 @@
+{
+  "namespace": "common",
+  "type": "record",
+  "name": "ChildB",
+  "fields": [
+    { "name": "streetaddress", "type": "string" },
+    { "name": "city", "type": "string" }
+  ]
+}

--- a/tests/test_cases_expandable/domain.Parent.avsc
+++ b/tests/test_cases_expandable/domain.Parent.avsc
@@ -1,0 +1,30 @@
+{
+  "namespace": "domain",
+  "type": "record",
+  "name": "Parent",
+  "fields": [
+    {
+      "name": "first_item",
+      "type": "common.ChildA"
+    },
+    {
+      "name": "second_item",
+      "type": "common.ChildA"
+    },
+    {
+      "name": "composite_item",
+      "type": {
+        "type": "record",
+        "name": "CompositeItem",
+        "fields": [
+          { "name": "composite_a", "type": "common.ChildA" },
+          { "name": "composite_b", "type": "common.ChildB" }
+        ]
+      }
+    },
+    {
+      "name": "favorite_color",
+      "type": ["string", "null"]
+    }
+  ]
+}

--- a/tests/test_schema_to_typed_dict.py
+++ b/tests/test_schema_to_typed_dict.py
@@ -1,15 +1,33 @@
 import glob
-from avro_to_python_types import schema_to_typed_dict
+from avro_to_python_types import (
+    typed_dict_from_schema_string,
+    typed_dict_from_schema_file,
+)
 import snapshottest
 
-test_json_files = glob.glob("tests/test_cases/*.avsc")
+test_schema_files = glob.glob("tests/test_cases/*.avsc")
+expandable_schema_files = glob.glob("tests/test_cases_expandable/*.avsc")
 
 
-class SnapshotSchemaToTypedDict(snapshottest.TestCase):
+class SnapshotTypedDictFromSchemaFile(snapshottest.TestCase):
+    def test_snapshot_self_contained_schemas(self):
+        for test_schema_file in test_schema_files:
+            test_output = typed_dict_from_schema_file(test_schema_file)
+            schema_name = test_schema_file.rsplit("/", 1)[-1]
+            self.assertMatchSnapshot(test_output, schema_name)
+
+    def test_snapshot_expandable_schemas(self):
+        for test_schema_file in expandable_schema_files:
+            test_output = typed_dict_from_schema_file(test_schema_file)
+            schema_name = test_schema_file.rsplit("/", 1)[-1]
+            self.assertMatchSnapshot(test_output, schema_name)
+
+
+class SnapshotTypedDictFromSchemaString(snapshottest.TestCase):
     def test_snapshot_all_schemas(self):
-        for test_json_file in test_json_files:
+        for test_json_file in test_schema_files:
             with open(test_json_file) as f:
                 avro_schema = f.read()
-            test_output = schema_to_typed_dict(avro_schema)
+            test_output = typed_dict_from_schema_string(avro_schema)
             schema_name = test_json_file.rsplit("/", 1)[-1]
             self.assertMatchSnapshot(test_output, schema_name)


### PR DESCRIPTION
The Avro spec supports referencing other schemas by their full name, a concatenation of namespace + name. We would like to support typegen for this.

This PR adds typegen for types referenced by fullname for schemas that are loaded by files. We do this by utilizing [fastavro](https://github.com/fastavro/fastavro), which expects all schemas to be in the same directory.


Breaking Changes:
- `schema_to_typed_dict` is now `typed_dict_from_schema_string`
- type names are now prepended with their namespace