### PR TITLE
Pep 8 class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0
+
+### Breaking Changes
+
+- Generated classes now follow proper PEP 8 naming convention: https://www.python.org/dev/peps/pep-0008/#class-names
 ## 0.2.2
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -90,17 +90,17 @@ The following example shows the type generated for a given schema.
 ```python
 from typing import TypedDict, Optional
 
-class example_AddressUSRecord(TypedDict):
+class ExampleAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class example_OtherThing(TypedDict):
+class ExampleOtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class example_User(TypedDict):
+class ExampleUser(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]

--- a/avro_to_python_types/__init__.py
+++ b/avro_to_python_types/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 from .typed_dict_from_schema import (
     typed_dict_from_schema_file,
     typed_dict_from_schema_string,

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -49,7 +49,7 @@ def types_for_schema(schema):
     body = tree.body
 
     def type_for_schema_record(record_schema):
-        type_name = record_schema["name"].replace(".", "_")
+        type_name = ''.join(word[0].upper() + word[1:] for word in record_schema['name'].split('.'))
         our_type = GenerateTypedDict(type_name)
         for field in record_schema["fields"]:
             name = field["name"]

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -49,7 +49,9 @@ def types_for_schema(schema):
     body = tree.body
 
     def type_for_schema_record(record_schema):
-        type_name = ''.join(word[0].upper() + word[1:] for word in record_schema['name'].split('.'))
+        type_name = "".join(
+            word[0].upper() + word[1:] for word in record_schema["name"].split(".")
+        )
         our_type = GenerateTypedDict(type_name)
         for field in record_schema["fields"]:
             name = field["name"]

--- a/examples/sync_types/types/nested_record.py
+++ b/examples/sync_types/types/nested_record.py
@@ -1,13 +1,12 @@
 from typing import TypedDict, Optional
 
-
-class example_avro_AddressUSRecord(TypedDict):
+class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class example_avro_User(TypedDict):
+class ExampleAvroUser(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: example_avro_AddressUSRecord
+    address: ExampleAvroAddressUSRecord

--- a/examples/sync_types/types/nested_record.py
+++ b/examples/sync_types/types/nested_record.py
@@ -1,5 +1,6 @@
 from typing import TypedDict, Optional
 
+
 class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str

--- a/examples/sync_types/types/nested_records.py
+++ b/examples/sync_types/types/nested_records.py
@@ -1,5 +1,6 @@
 from typing import TypedDict, Optional
 
+
 class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str

--- a/examples/sync_types/types/nested_records.py
+++ b/examples/sync_types/types/nested_records.py
@@ -1,19 +1,18 @@
 from typing import TypedDict, Optional
 
-
-class example_avro_AddressUSRecord(TypedDict):
+class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class example_avro_OtherThing(TypedDict):
+class ExampleAvroOtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class example_avro_User(TypedDict):
+class ExampleAvroUser(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: example_avro_AddressUSRecord
-    other_thing: example_avro_OtherThing
+    address: ExampleAvroAddressUSRecord
+    other_thing: ExampleAvroOtherThing

--- a/examples/sync_types/types/nested_records_deep.py
+++ b/examples/sync_types/types/nested_records_deep.py
@@ -1,24 +1,23 @@
 from typing import TypedDict, Optional
 
-
-class example_avro_AddressUSRecord(TypedDict):
+class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class example_avro_NextOtherThing(TypedDict):
+class ExampleAvroNextOtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class example_avro_OtherThing(TypedDict):
+class ExampleAvroOtherThing(TypedDict):
     thing1: str
-    other_thing: example_avro_NextOtherThing
+    other_thing: ExampleAvroNextOtherThing
 
 
-class example_avro_User(TypedDict):
+class ExampleAvroUser(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: example_avro_AddressUSRecord
-    other_thing: example_avro_OtherThing
+    address: ExampleAvroAddressUSRecord
+    other_thing: ExampleAvroOtherThing

--- a/examples/sync_types/types/nested_records_deep.py
+++ b/examples/sync_types/types/nested_records_deep.py
@@ -1,5 +1,6 @@
 from typing import TypedDict, Optional
 
+
 class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "avro-to-python-types"
-version = "0.2.2"
+version = "0.3.0"
 description = "A library for converting avro schemas to python types."
 readme = "README.md"
 authors = ["Dan Green-Leipciger"]

--- a/tests/snapshots/snap_test_schema_to_typed_dict.py
+++ b/tests/snapshots/snap_test_schema_to_typed_dict.py
@@ -9,7 +9,7 @@ snapshots = Snapshot()
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildA.avsc'] = '''from typing import TypedDict, Optional
 
-class common_ChildA(TypedDict):
+class CommonChildA(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
@@ -17,150 +17,150 @@ class common_ChildA(TypedDict):
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildB.avsc'] = '''from typing import TypedDict, Optional
 
-class common_ChildB(TypedDict):
+class CommonChildB(TypedDict):
     streetaddress: str
     city: str
 '''
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas domain.Parent.avsc'] = '''from typing import TypedDict, Optional
 
-class common_ChildA(TypedDict):
+class CommonChildA(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
 
 
-class common_ChildB(TypedDict):
+class CommonChildB(TypedDict):
     streetaddress: str
     city: str
 
 
-class domain_CompositeItem(TypedDict):
-    composite_a: common_ChildA
-    composite_b: common_ChildB
+class DomainCompositeItem(TypedDict):
+    composite_a: CommonChildA
+    composite_b: CommonChildB
 
 
-class domain_Parent(TypedDict):
-    first_item: common_ChildA
-    second_item: common_ChildA
-    composite_item: domain_CompositeItem
+class DomainParent(TypedDict):
+    first_item: CommonChildA
+    second_item: CommonChildA
+    composite_item: DomainCompositeItem
     favorite_color: Optional[str]
 '''
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_record.avsc'] = '''from typing import TypedDict, Optional
 
-class example_avro_AddressUSRecord(TypedDict):
+class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class example_avro_User(TypedDict):
+class ExampleAvroUser(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: example_avro_AddressUSRecord
+    address: ExampleAvroAddressUSRecord
 '''
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records.avsc'] = '''from typing import TypedDict, Optional
 
-class example_AddressUSRecord(TypedDict):
+class ExampleAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class example_OtherThing(TypedDict):
+class ExampleOtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class example_User(TypedDict):
+class ExampleUser(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: example_AddressUSRecord
-    other_thing: example_OtherThing
+    address: ExampleAddressUSRecord
+    other_thing: ExampleOtherThing
 '''
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records_deep.avsc'] = '''from typing import TypedDict, Optional
 
-class example_avro_AddressUSRecord(TypedDict):
+class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class example_avro_NextOtherThing(TypedDict):
+class ExampleAvroNextOtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class example_avro_OtherThing(TypedDict):
+class ExampleAvroOtherThing(TypedDict):
     thing1: str
-    other_thing: example_avro_NextOtherThing
+    other_thing: ExampleAvroNextOtherThing
 
 
-class example_avro_User(TypedDict):
+class ExampleAvroUser(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: example_avro_AddressUSRecord
-    other_thing: example_avro_OtherThing
+    address: ExampleAvroAddressUSRecord
+    other_thing: ExampleAvroOtherThing
 '''
 
 snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_record.avsc'] = '''from typing import TypedDict, Optional
 
-class example_avro_AddressUSRecord(TypedDict):
+class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class example_avro_User(TypedDict):
+class ExampleAvroUser(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: example_avro_AddressUSRecord
+    address: ExampleAvroAddressUSRecord
 '''
 
 snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records.avsc'] = '''from typing import TypedDict, Optional
 
-class example_AddressUSRecord(TypedDict):
+class ExampleAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class example_OtherThing(TypedDict):
+class ExampleOtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class example_User(TypedDict):
+class ExampleUser(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: example_AddressUSRecord
-    other_thing: example_OtherThing
+    address: ExampleAddressUSRecord
+    other_thing: ExampleOtherThing
 '''
 
 snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records_deep.avsc'] = '''from typing import TypedDict, Optional
 
-class example_avro_AddressUSRecord(TypedDict):
+class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
 
 
-class example_avro_NextOtherThing(TypedDict):
+class ExampleAvroNextOtherThing(TypedDict):
     thing1: str
     thing2: Optional[int]
 
 
-class example_avro_OtherThing(TypedDict):
+class ExampleAvroOtherThing(TypedDict):
     thing1: str
-    other_thing: example_avro_NextOtherThing
+    other_thing: ExampleAvroNextOtherThing
 
 
-class example_avro_User(TypedDict):
+class ExampleAvroUser(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
-    address: example_avro_AddressUSRecord
-    other_thing: example_avro_OtherThing
+    address: ExampleAvroAddressUSRecord
+    other_thing: ExampleAvroOtherThing
 '''


### PR DESCRIPTION
This PR fixes the generated classes to use [PEP 8](https://www.python.org/dev/peps/pep-0008/#class-names) naming conventions.