### PR TITLE
Add logical types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 .pytest_cache
 dist
+**/.DS_store

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ schema_files = glob.glob("schemas/*.avsc")
 
 for schema_file in schema_files:
     types = typed_dict_from_schema_file(schema_file)
-    print(types)
+    print(types) 
 
 ```
 

--- a/avro_to_python_types/schema_mapping.py
+++ b/avro_to_python_types/schema_mapping.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 prim_to_type = {
     "null": "None",
     "boolean": "bool",
@@ -9,4 +10,13 @@ prim_to_type = {
     "double": "float",
     "bytes": "bytes",
     "string": "str",
+}
+
+
+logical_to_python_type = {
+    "date": "datetime.date",
+    "time-millis": "datetime.time",
+    "timestamp-millis": "datetime.datetime",
+    "uuid": "uuid.UUID",
+    "decimal": "decimal.Decimal",
 }

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -1,5 +1,5 @@
 from .generate_typed_dict import GenerateTypedDict
-from .schema_mapping import prim_to_type
+from .schema_mapping import prim_to_type, logical_to_python_type
 from fastavro.schema import load_schema, expand_schema, parse_schema
 import ast
 import json
@@ -8,15 +8,54 @@ import astor
 
 def is_nullable(field):
     if isinstance(field["type"], list):
-        if field["type"][0] == "null":
-            return True
+        for ftype in field["type"]:
+            if ftype == "null":
+                return True
     return False
 
 
 def is_nested(field):
-    if isinstance(field["type"], dict):
+    if isinstance(field["type"], dict) and not is_logical_type(field["type"]):
         return True
     return False
+
+
+def is_logical_type(field_type):
+    if isinstance(field_type, list):
+        for ftype in field_type:
+            if ftype != "null" and isinstance(ftype, dict):
+                return "logicalType" in ftype
+    elif isinstance(field_type, dict):
+        return "logicalType" in field_type
+    return False
+
+
+def get_type(types):
+    if not isinstance(types, list) and not isinstance(types, dict):
+        return types
+    elif isinstance(types, dict):
+        return types["type"]
+    for ftype in types:
+        if ftype != "null":
+            return ftype
+    raise ValueError("no valid type in list: {}".format(types))
+
+
+def get_logical_type(types):
+    if not isinstance(types, list) and not isinstance(types, dict):
+        raise ValueError("not a logical type: {}".format(types))
+    elif isinstance(types, dict):
+        return types["logicalType"]
+    for ftype in types:
+        if isinstance(ftype, dict):
+            return ftype["logicalType"]
+    raise ValueError("unexpected error in logical type: {}".format(types))
+
+
+def is_logical(field):
+    return (
+        isinstance(field["type"], dict) or isinstance(field["type"], list)
+    ) and is_logical_type(field["type"])
 
 
 def _dedupe_ast(tree):
@@ -43,12 +82,16 @@ def _dedupe_ast(tree):
 
 
 def types_for_schema(schema):
-
+    """
+    This is the main function for the module.  It will parse a schema and return a concrete type
+    which extends the TypedDict class.  It currently supports all primitive types as well as
+    logical types except for the microsecond precision time types.
+    """
     body = []
     tree = ast.Module(body)
     body = tree.body
 
-    def type_for_schema_record(record_schema):
+    def type_for_schema_record(record_schema, imports):
         type_name = "".join(
             word[0].upper() + word[1:] for word in record_schema["name"].split(".")
         )
@@ -56,27 +99,37 @@ def types_for_schema(schema):
         for field in record_schema["fields"]:
             name = field["name"]
             if is_nested(field):
-                nested = type_for_schema_record(field["type"])
+                nested = type_for_schema_record(field["type"], imports)
                 body.append(nested.tree)
                 if is_nullable(field):
                     our_type.add_optional_element(name, nested.name)
                 else:
                     our_type.add_required_element(name, nested.name)
                 continue
-            if is_nullable(field):
-                type = field["type"][1]
-                our_type.add_optional_element(name, prim_to_type[type])
+            if is_logical(field):
+                logical_type = logical_to_python_type[get_logical_type(field["type"])]
+                imports.append(
+                    "from {} import {}\n".format(
+                        logical_type.split(".")[0], logical_type.split(".")[1]
+                    )
+                )
+                if is_nullable(field):
+                    our_type.add_optional_element(name, logical_type.split(".")[1])
+                else:
+                    our_type.add_required_element(name, logical_type.split(".")[1])
             else:
-                type = field["type"]
-                our_type.add_required_element(name, prim_to_type[type])
+                type = get_type(field["type"])
+                if is_nullable(field):
+                    our_type.add_optional_element(name, prim_to_type[type])
+                else:
+                    our_type.add_required_element(name, prim_to_type[type])
         return our_type
 
-    main_type = type_for_schema_record(schema)
+    imports = ["from typing import TypedDict, Optional\n"]
+    main_type = type_for_schema_record(schema, imports)
     body.append(main_type.tree)
-
-    imports = "from typing import TypedDict, Optional\n\n"
-    types = astor.to_source(_dedupe_ast(tree))
-    return imports + types
+    imports = sorted(list(set(imports)))
+    return "".join(imports) + "\n\n" + astor.to_source(_dedupe_ast(tree))
 
 
 def typed_dict_from_schema_string(schema_string):
@@ -86,5 +139,4 @@ def typed_dict_from_schema_string(schema_string):
 
 def typed_dict_from_schema_file(schema_path):
     schema = expand_schema(load_schema(schema_path))
-
     return types_for_schema(schema)

--- a/examples/sync_types/schemas/nested_record.avsc
+++ b/examples/sync_types/schemas/nested_record.avsc
@@ -6,6 +6,12 @@
     { "name": "name", "type": "string" },
     { "name": "favorite_number", "type": ["null", "int"] },
     { "name": "favorite_color", "type": ["null", "string"] },
+    { "name": "birthdate", "type": { "type":"int", "logicalType":"date"}},
+    { "name": "appt_date", "type": { "type": "int", "logicalType":"date" }},
+    { "name": "time_of_day_birth", "type": { "type":"int", "logicalType":"time-millis" }},
+    { "name": "timestamp_of_birth", "type": { "type": "long", "logicalType":"timestamp-millis" }},
+    { "name": "uuid_of_birth_record", "type": { "type": "string", "logicalType":"uuid" }},
+    { "name": "weight", "type": {"type": "bytes", "logicalType":"decimal" ,"precision": 5,"scale":2}},
     {
       "name": "address",
       "type": {

--- a/examples/sync_types/types/nested_record.py
+++ b/examples/sync_types/types/nested_record.py
@@ -1,4 +1,9 @@
+from datetime import date
+from datetime import datetime
+from datetime import time
+from decimal import Decimal
 from typing import TypedDict, Optional
+from uuid import UUID
 
 
 class ExampleAvroAddressUSRecord(TypedDict):
@@ -10,4 +15,10 @@ class ExampleAvroUser(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
+    birthdate: date
+    appt_date: date
+    time_of_day_birth: time
+    timestamp_of_birth: datetime
+    uuid_of_birth_record: UUID
+    weight: Decimal
     address: ExampleAvroAddressUSRecord

--- a/tests/snapshots/snap_test_schema_to_typed_dict.py
+++ b/tests/snapshots/snap_test_schema_to_typed_dict.py
@@ -9,20 +9,58 @@ snapshots = Snapshot()
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildA.avsc'] = '''from typing import TypedDict, Optional
 
+
 class CommonChildA(TypedDict):
     name: str
     favorite_number: Optional[int]
     favorite_color: Optional[str]
 '''
 
-snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildB.avsc'] = '''from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildB.avsc'] = '''from datetime import date
+from datetime import datetime
+from datetime import time
+from decimal import Decimal
+from typing import TypedDict, Optional
+from uuid import UUID
+
 
 class CommonChildB(TypedDict):
     streetaddress: str
     city: str
+    birthdate: date
+    appt_date: date
+    time_of_day_birth: time
+    timestamp_of_birth: datetime
+    uuid_of_birth_record: UUID
+    weight: Decimal
 '''
 
-snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas domain.Parent.avsc'] = '''from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildC.avsc'] = '''from datetime import date
+from datetime import datetime
+from datetime import time
+from decimal import Decimal
+from typing import TypedDict, Optional
+from uuid import UUID
+
+
+class CommonChildB(TypedDict):
+    streetaddress: Optional[str]
+    city: Optional[str]
+    birthdate: date
+    appt_date: date
+    time_of_day_birth: Optional[time]
+    timestamp_of_birth: datetime
+    uuid_of_birth_record: UUID
+    weight: Decimal
+'''
+
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas domain.Parent.avsc'] = '''from datetime import date
+from datetime import datetime
+from datetime import time
+from decimal import Decimal
+from typing import TypedDict, Optional
+from uuid import UUID
+
 
 class CommonChildA(TypedDict):
     name: str
@@ -33,6 +71,12 @@ class CommonChildA(TypedDict):
 class CommonChildB(TypedDict):
     streetaddress: str
     city: str
+    birthdate: date
+    appt_date: date
+    time_of_day_birth: time
+    timestamp_of_birth: datetime
+    uuid_of_birth_record: UUID
+    weight: Decimal
 
 
 class DomainCompositeItem(TypedDict):
@@ -49,6 +93,7 @@ class DomainParent(TypedDict):
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_record.avsc'] = '''from typing import TypedDict, Optional
 
+
 class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
@@ -62,6 +107,7 @@ class ExampleAvroUser(TypedDict):
 '''
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records.avsc'] = '''from typing import TypedDict, Optional
+
 
 class ExampleAddressUSRecord(TypedDict):
     streetaddress: str
@@ -82,6 +128,7 @@ class ExampleUser(TypedDict):
 '''
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records_deep.avsc'] = '''from typing import TypedDict, Optional
+
 
 class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
@@ -108,6 +155,7 @@ class ExampleAvroUser(TypedDict):
 
 snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_record.avsc'] = '''from typing import TypedDict, Optional
 
+
 class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str
     city: str
@@ -121,6 +169,7 @@ class ExampleAvroUser(TypedDict):
 '''
 
 snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records.avsc'] = '''from typing import TypedDict, Optional
+
 
 class ExampleAddressUSRecord(TypedDict):
     streetaddress: str
@@ -141,6 +190,7 @@ class ExampleUser(TypedDict):
 '''
 
 snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records_deep.avsc'] = '''from typing import TypedDict, Optional
+
 
 class ExampleAvroAddressUSRecord(TypedDict):
     streetaddress: str

--- a/tests/snapshots/snap_test_sync_types.py
+++ b/tests/snapshots/snap_test_sync_types.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import GenericRepr, Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['SnapshotTestSyncedTypes::test_synced_types test_synced_types1'] = {
+    'address': {
+        'city': 'bergsville',
+        'streetaddress': '154 Sparkling Heaven Dr'
+    },
+    'appt_date': GenericRepr('datetime.date(1993, 4, 21)'),
+    'birthdate': GenericRepr('datetime.date(1989, 1, 11)'),
+    'favorite_color': 'cyan',
+    'favorite_number': 41,
+    'name': 'walter',
+    'time_of_day_birth': GenericRepr('datetime.time(12, 21, 45, 3000)'),
+    'timestamp_of_birth': GenericRepr('datetime.datetime(1989, 1, 11, 1, 21, 45, tzinfo=datetime.timezone.utc)'),
+    'uuid_of_birth_record': GenericRepr("UUID('e6a848a6-2682-4e9c-afe2-895f9bd45ff8')"),
+    'weight': GenericRepr("Decimal('12.55')")
+}
+
+snapshots['SnapshotTestSyncedTypes::test_synced_types test_synced_types2'] = {
+    'address': {
+        'city': 'Dulock',
+        'streetaddress': '1 Bowling Lawn Green'
+    },
+    'appt_date': GenericRepr('datetime.date(1993, 2, 21)'),
+    'birthdate': GenericRepr('datetime.date(1999, 1, 11)'),
+    'favorite_color': 'red',
+    'favorite_number': 666,
+    'name': 'george',
+    'time_of_day_birth': GenericRepr('datetime.time(4, 21, 45, 5000)'),
+    'timestamp_of_birth': GenericRepr('datetime.datetime(1999, 2, 11, 2, 22, 45, tzinfo=datetime.timezone.utc)'),
+    'uuid_of_birth_record': GenericRepr("UUID('6c6a29f9-185e-476f-8055-ec91530ee561')"),
+    'weight': GenericRepr("Decimal('44.55')")
+}
+
+snapshots['SnapshotTestSyncedTypes::test_synced_types test_synced_types3'] = {
+    'address': {
+        'city': 'Springfield',
+        'streetaddress': '66 Springfield Cr'
+    },
+    'appt_date': GenericRepr('datetime.date(1944, 4, 21)'),
+    'birthdate': GenericRepr('datetime.date(1911, 1, 11)'),
+    'favorite_color': 'black',
+    'favorite_number': 92,
+    'name': 'marie',
+    'time_of_day_birth': GenericRepr('datetime.time(1, 13, 37, 9000)'),
+    'timestamp_of_birth': GenericRepr('datetime.datetime(1989, 1, 11, 3, 21, 45, tzinfo=datetime.timezone.utc)'),
+    'uuid_of_birth_record': GenericRepr("UUID('6c6a29f9-185e-476f-8055-ec91530ee561')"),
+    'weight': GenericRepr("Decimal('26.30')")
+}

--- a/tests/test_cases_expandable/common.ChildA.avsc
+++ b/tests/test_cases_expandable/common.ChildA.avsc
@@ -4,7 +4,7 @@
   "name": "ChildA",
   "fields": [
     { "name": "name", "type": "string" },
-    { "name": "favorite_number", "type": ["null", "int"] },
+    { "name": "favorite_number", "type": ["int", "null"] },
     { "name": "favorite_color", "type": ["null", "string"] }
   ]
 }

--- a/tests/test_cases_expandable/common.ChildC.avsc
+++ b/tests/test_cases_expandable/common.ChildC.avsc
@@ -3,11 +3,11 @@
   "type": "record",
   "name": "ChildB",
   "fields": [
-    { "name": "streetaddress", "type": "string" },
-    { "name": "city", "type": "string" },
+    { "name": "streetaddress", "type": ["null","string"] },
+    { "name": "city", "type":[ "string","null"] },
     { "name": "birthdate", "type": { "type":"int", "logicalType":"date" }},
     { "name": "appt_date", "type": { "type" : "int", "logicalType":"date" }},
-    { "name": "time_of_day_birth", "type": { "type": "int", "logicalType":"time-millis" }},
+    { "name": "time_of_day_birth", "type":[ { "type": "int", "logicalType":"time-millis" },"null"]},
     { "name": "timestamp_of_birth", "type": { "type": "long", "logicalType":"timestamp-millis" }},
     { "name": "uuid_of_birth_record", "type": { "type": "string", "logicalType":"uuid" }},
     { "name": "weight", "type": {"type": "bytes", "logicalType":"decimal" ,"precision": 5,"scale":2}}

--- a/tests/test_sync_types.py
+++ b/tests/test_sync_types.py
@@ -1,0 +1,146 @@
+from fastavro import writer, reader, parse_schema
+from datetime import date, time, datetime, timezone
+from uuid import UUID
+from decimal import Decimal
+from typing import TypedDict, Optional
+import snapshottest
+
+
+nested_record_schema = {
+    "namespace": "example.avro",
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {"name": "name", "type": "string"},
+        {"name": "favorite_number", "type": ["null", "int"]},
+        {"name": "favorite_color", "type": ["null", "string"]},
+        {"name": "birthdate", "type": {"type": "int", "logicalType": "date"}},
+        {"name": "appt_date", "type": {"type": "int", "logicalType": "date"}},
+        {
+            "name": "time_of_day_birth",
+            "type": {"type": "int", "logicalType": "time-millis"},
+        },
+        {
+            "name": "timestamp_of_birth",
+            "type": {"type": "long", "logicalType": "timestamp-millis"},
+        },
+        {
+            "name": "uuid_of_birth_record",
+            "type": {"type": "string", "logicalType": "uuid"},
+        },
+        {
+            "name": "weight",
+            "type": {
+                "type": "bytes",
+                "logicalType": "decimal",
+                "precision": 5,
+                "scale": 2,
+            },
+        },
+        {
+            "name": "address",
+            "type": {
+                "type": "record",
+                "name": "AddressUSRecord",
+                "fields": [
+                    {"name": "streetaddress", "type": "string"},
+                    {"name": "city", "type": "string"},
+                ],
+            },
+        },
+    ],
+}
+
+
+class ExampleAvroAddressUSRecord(TypedDict):
+    streetaddress: str
+    city: str
+
+
+class ExampleAvroUser(TypedDict):
+    name: str
+    favorite_number: Optional[int]
+    favorite_color: Optional[str]
+    birthdate: date
+    appt_date: date
+    time_of_day_birth: time
+    timestamp_of_birth: datetime
+    uuid_of_birth_record: UUID
+    weight: Decimal
+    address: ExampleAvroAddressUSRecord
+
+
+class SnapshotTestSyncedTypes(snapshottest.TestCase):
+    def test_synced_types(self):
+        """The nested_record_schema was parsed using this package to create the concrete class 'ExampleAvroUser' above.
+        This test uses fastavro to serialize ExampleAvroUser and then deserialize it and compares the result to
+        a snapshot.
+            Note: that the datetime fields have utc time zones associated with them because the datetime package
+            assumes that if the timezone is not provided it is local, however the fastavro package will default it
+            to utc when when serializing it.  So if you serialize and deserialize something with a 'niave' datetime
+            variable the resulting value will not match the original and will differ by your offset from utc.
+            Worse still if you serialize such a variable in one timezone and deserialize it in another the results will not
+            differ by the same amount!  Thus defeating any local adjustment you had in place.  This could be serious for
+            code that runs accross AWS regions.
+        """
+        self.maxDiff = None
+        parsed_schema = parse_schema(nested_record_schema)
+        records: list(ExampleAvroUser) = [
+            {
+                "name": "walter",
+                "favorite_number": 41,
+                "favorite_color": "cyan",
+                "birthdate": date(1989, 1, 11),
+                "appt_date": date(1993, 4, 21),
+                "time_of_day_birth": time(12, 21, 45, 3456),
+                "timestamp_of_birth": datetime(
+                    1989, 1, 11, 1, 21, 45, tzinfo=timezone.utc
+                ),
+                "uuid_of_birth_record": "e6a848a6-2682-4e9c-afe2-895f9bd45ff8",
+                "weight": Decimal(12.55).__round__(2),
+                "address": {
+                    "streetaddress": "154 Sparkling Heaven Dr",
+                    "city": "bergsville",
+                },
+            },
+            {
+                "name": "george",
+                "favorite_number": 666,
+                "favorite_color": "red",
+                "birthdate": date(1999, 1, 11),
+                "appt_date": date(1993, 2, 21),
+                "time_of_day_birth": time(4, 21, 45, 5678),
+                "timestamp_of_birth": datetime(
+                    1999, 2, 11, 2, 22, 45, tzinfo=timezone.utc
+                ),
+                "uuid_of_birth_record": "6c6a29f9-185e-476f-8055-ec91530ee561",
+                "weight": Decimal(44.55).__round__(2),
+                "address": {"streetaddress": "1 Bowling Lawn Green", "city": "Dulock"},
+            },
+            {
+                "name": "marie",
+                "favorite_number": 92,
+                "favorite_color": "black",
+                "birthdate": date(1911, 1, 11),
+                "appt_date": date(1944, 4, 21),
+                "time_of_day_birth": time(1, 13, 37, 9878),
+                "timestamp_of_birth": datetime(
+                    1989, 1, 11, 3, 21, 45, tzinfo=timezone.utc
+                ),
+                "uuid_of_birth_record": "6c6a29f9-185e-476f-8055-ec91530ee561",
+                "weight": Decimal(26.3).__round__(2),
+                "address": {
+                    "streetaddress": "66 Springfield Cr",
+                    "city": "Springfield",
+                },
+            },
+        ]
+
+        with open(f"/tmp/nested_type.avro", "wb") as message_out:
+            writer(message_out, parsed_schema, records)
+
+        with open(f"/tmp/nested_type.avro", "rb") as message_in:
+            i = 1
+            for record in reader(message_in):
+                self.assertMatchSnapshot(record, name=f"test_synced_types{i}")
+                i += 1


### PR DESCRIPTION
Add the logical values defined in the avro schema to the TypedDict classes generated by this project.  Except for the microsecond values, which we don't (at present) anticipate using.
[https://avro.apache.org/docs/current/spec.html](https://avro.apache.org/docs/current/spec.html)
They are:
date
time
datetime
uuid
Decimal
