### PR TITLE
Add the Optional type only when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.5.0
+### Changed
+- The `Optional` type is imported only if necessary
+- If both `Optional` and `TypedDict` are imported, the imports are sorted
+
 ## 0.4.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 ## 0.5.0
 ### Changed
-- The `Optional` type is imported only if necessary
-- If both `Optional` and `TypedDict` are imported, the imports are sorted
+- The `Optional` type is imported only if necessary.
+- If both `Optional` and `TypedDict` are imported, the imports are sorted alphabetically.
 
 ## 0.4.0
 

--- a/avro_to_python_types/__init__.py
+++ b/avro_to_python_types/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 from .typed_dict_from_schema import (
     typed_dict_from_schema_file,
     typed_dict_from_schema_string,

--- a/avro_to_python_types/constants.py
+++ b/avro_to_python_types/constants.py
@@ -1,0 +1,1 @@
+OPTIONAL = "Optional"

--- a/avro_to_python_types/generate_typed_dict.py
+++ b/avro_to_python_types/generate_typed_dict.py
@@ -1,6 +1,9 @@
 import astor
 import ast
 
+from .constants import OPTIONAL
+
+
 base = """
 class Example(TypedDict):
     foo: str
@@ -15,7 +18,7 @@ def required_element(name, type):
 
 def optional_element(name, type):
     target = ast.Name(id=name)
-    annotation = ast.Subscript(value=ast.Name(id="Optional"), slice=ast.Name(id=type))
+    annotation = ast.Subscript(value=ast.Name(id=OPTIONAL), slice=ast.Name(id=type))
     return ast.AnnAssign(target=target, annotation=annotation, simple=1)
 
 

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -1,3 +1,4 @@
+from .constants import OPTIONAL
 from .generate_typed_dict import GenerateTypedDict
 from .schema_mapping import prim_to_type, logical_to_python_type
 from fastavro.schema import load_schema, expand_schema, parse_schema
@@ -125,8 +126,13 @@ def types_for_schema(schema):
                     our_type.add_required_element(name, prim_to_type[type])
         return our_type
 
-    imports = ["from typing import TypedDict, Optional\n"]
+    imports = ["from typing import TypedDict\n"]
     main_type = type_for_schema_record(schema, imports)
+
+    # import the Optional type only if required
+    if OPTIONAL in ast.dump(main_type.tree):
+        imports.append(f"from typing import {OPTIONAL}\n")
+
     body.append(main_type.tree)
     imports = sorted(list(set(imports)))
     return "".join(imports) + "\n\n" + astor.to_source(_dedupe_ast(tree))

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -129,14 +129,14 @@ def types_for_schema(schema):
     imports = []
     main_type = type_for_schema_record(schema, imports)
 
-    addional_imports = []
+    addional_types = []
     # import the Optional type only if required
     if OPTIONAL in ast.dump(main_type.tree):
-        addional_imports.append(OPTIONAL)
-    addional_imports.append("TypedDict")
-    addional_imports_as_str = ", ".join(addional_imports)
+        addional_types.append(OPTIONAL)
+    addional_types.append("TypedDict")
+    addional_types_as_str = ", ".join(addional_types)
 
-    imports.append(f"from typing import {addional_imports_as_str}\n")
+    imports.append(f"from typing import {addional_types_as_str}\n")
 
     body.append(main_type.tree)
     imports = sorted(list(set(imports)))

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -129,14 +129,14 @@ def types_for_schema(schema):
     imports = []
     main_type = type_for_schema_record(schema, imports)
 
-    addional_types = []
+    additional_types = []
     # import the Optional type only if required
     if OPTIONAL in ast.dump(main_type.tree):
-        addional_types.append(OPTIONAL)
-    addional_types.append("TypedDict")
-    addional_types_as_str = ", ".join(addional_types)
+        additional_types.append(OPTIONAL)
+    additional_types.append("TypedDict")
+    additional_types_as_str = ", ".join(additional_types)
 
-    imports.append(f"from typing import {addional_types_as_str}\n")
+    imports.append(f"from typing import {additional_types_as_str}\n")
 
     body.append(main_type.tree)
     imports = sorted(list(set(imports)))

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -126,12 +126,17 @@ def types_for_schema(schema):
                     our_type.add_required_element(name, prim_to_type[type])
         return our_type
 
-    imports = ["from typing import TypedDict\n"]
+    imports = []
     main_type = type_for_schema_record(schema, imports)
 
+    addional_imports = []
     # import the Optional type only if required
     if OPTIONAL in ast.dump(main_type.tree):
-        imports.append(f"from typing import {OPTIONAL}\n")
+        addional_imports.append(OPTIONAL)
+    addional_imports.append("TypedDict")
+    addional_imports_as_str = ", ".join(addional_imports)
+
+    imports.append(f"from typing import {addional_imports_as_str}\n")
 
     body.append(main_type.tree)
     imports = sorted(list(set(imports)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "avro-to-python-types"
-version = "0.4.0"
+version = "0.5.0"
 description = "A library for converting avro schemas to python types."
 readme = "README.md"
 authors = ["Dan Green-Leipciger"]

--- a/tests/snapshots/snap_test_schema_to_typed_dict.py
+++ b/tests/snapshots/snap_test_schema_to_typed_dict.py
@@ -7,8 +7,7 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildA.avsc'] = '''from typing import Optional
-from typing import TypedDict
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildA.avsc'] = '''from typing import Optional, TypedDict
 
 
 class CommonChildA(TypedDict):
@@ -40,8 +39,7 @@ snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas com
 from datetime import datetime
 from datetime import time
 from decimal import Decimal
-from typing import Optional
-from typing import TypedDict
+from typing import Optional, TypedDict
 from uuid import UUID
 
 
@@ -60,8 +58,7 @@ snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas dom
 from datetime import datetime
 from datetime import time
 from decimal import Decimal
-from typing import Optional
-from typing import TypedDict
+from typing import Optional, TypedDict
 from uuid import UUID
 
 
@@ -94,8 +91,7 @@ class DomainParent(TypedDict):
     favorite_color: Optional[str]
 '''
 
-snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_record.avsc'] = '''from typing import Optional
-from typing import TypedDict
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_record.avsc'] = '''from typing import Optional, TypedDict
 
 
 class ExampleAvroAddressUSRecord(TypedDict):
@@ -110,8 +106,7 @@ class ExampleAvroUser(TypedDict):
     address: ExampleAvroAddressUSRecord
 '''
 
-snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records.avsc'] = '''from typing import Optional
-from typing import TypedDict
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records.avsc'] = '''from typing import Optional, TypedDict
 
 
 class ExampleAddressUSRecord(TypedDict):
@@ -132,8 +127,7 @@ class ExampleUser(TypedDict):
     other_thing: ExampleOtherThing
 '''
 
-snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records_deep.avsc'] = '''from typing import Optional
-from typing import TypedDict
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records_deep.avsc'] = '''from typing import Optional, TypedDict
 
 
 class ExampleAvroAddressUSRecord(TypedDict):
@@ -166,8 +160,7 @@ class ExampleAvroAnotherExample(TypedDict):
     id: str
 '''
 
-snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_record.avsc'] = '''from typing import Optional
-from typing import TypedDict
+snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_record.avsc'] = '''from typing import Optional, TypedDict
 
 
 class ExampleAvroAddressUSRecord(TypedDict):
@@ -182,8 +175,7 @@ class ExampleAvroUser(TypedDict):
     address: ExampleAvroAddressUSRecord
 '''
 
-snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records.avsc'] = '''from typing import Optional
-from typing import TypedDict
+snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records.avsc'] = '''from typing import Optional, TypedDict
 
 
 class ExampleAddressUSRecord(TypedDict):
@@ -204,8 +196,7 @@ class ExampleUser(TypedDict):
     other_thing: ExampleOtherThing
 '''
 
-snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records_deep.avsc'] = '''from typing import Optional
-from typing import TypedDict
+snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records_deep.avsc'] = '''from typing import Optional, TypedDict
 
 
 class ExampleAvroAddressUSRecord(TypedDict):

--- a/tests/snapshots/snap_test_schema_to_typed_dict.py
+++ b/tests/snapshots/snap_test_schema_to_typed_dict.py
@@ -7,7 +7,8 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildA.avsc'] = '''from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildA.avsc'] = '''from typing import Optional
+from typing import TypedDict
 
 
 class CommonChildA(TypedDict):
@@ -20,7 +21,7 @@ snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas com
 from datetime import datetime
 from datetime import time
 from decimal import Decimal
-from typing import TypedDict, Optional
+from typing import TypedDict
 from uuid import UUID
 
 
@@ -39,7 +40,8 @@ snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas com
 from datetime import datetime
 from datetime import time
 from decimal import Decimal
-from typing import TypedDict, Optional
+from typing import Optional
+from typing import TypedDict
 from uuid import UUID
 
 
@@ -58,7 +60,8 @@ snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas dom
 from datetime import datetime
 from datetime import time
 from decimal import Decimal
-from typing import TypedDict, Optional
+from typing import Optional
+from typing import TypedDict
 from uuid import UUID
 
 
@@ -91,7 +94,8 @@ class DomainParent(TypedDict):
     favorite_color: Optional[str]
 '''
 
-snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_record.avsc'] = '''from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_record.avsc'] = '''from typing import Optional
+from typing import TypedDict
 
 
 class ExampleAvroAddressUSRecord(TypedDict):
@@ -106,7 +110,8 @@ class ExampleAvroUser(TypedDict):
     address: ExampleAvroAddressUSRecord
 '''
 
-snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records.avsc'] = '''from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records.avsc'] = '''from typing import Optional
+from typing import TypedDict
 
 
 class ExampleAddressUSRecord(TypedDict):
@@ -127,7 +132,8 @@ class ExampleUser(TypedDict):
     other_thing: ExampleOtherThing
 '''
 
-snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records_deep.avsc'] = '''from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_records_deep.avsc'] = '''from typing import Optional
+from typing import TypedDict
 
 
 class ExampleAvroAddressUSRecord(TypedDict):
@@ -153,7 +159,15 @@ class ExampleAvroUser(TypedDict):
     other_thing: ExampleAvroOtherThing
 '''
 
-snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_record.avsc'] = '''from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas no_optional_field_record.avsc'] = '''from typing import TypedDict
+
+
+class ExampleAvroAnotherExample(TypedDict):
+    id: str
+'''
+
+snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_record.avsc'] = '''from typing import Optional
+from typing import TypedDict
 
 
 class ExampleAvroAddressUSRecord(TypedDict):
@@ -168,7 +182,8 @@ class ExampleAvroUser(TypedDict):
     address: ExampleAvroAddressUSRecord
 '''
 
-snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records.avsc'] = '''from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records.avsc'] = '''from typing import Optional
+from typing import TypedDict
 
 
 class ExampleAddressUSRecord(TypedDict):
@@ -189,7 +204,8 @@ class ExampleUser(TypedDict):
     other_thing: ExampleOtherThing
 '''
 
-snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records_deep.avsc'] = '''from typing import TypedDict, Optional
+snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas nested_records_deep.avsc'] = '''from typing import Optional
+from typing import TypedDict
 
 
 class ExampleAvroAddressUSRecord(TypedDict):
@@ -213,4 +229,11 @@ class ExampleAvroUser(TypedDict):
     favorite_color: Optional[str]
     address: ExampleAvroAddressUSRecord
     other_thing: ExampleAvroOtherThing
+'''
+
+snapshots['SnapshotTypedDictFromSchemaString::test_snapshot_all_schemas no_optional_field_record.avsc'] = '''from typing import TypedDict
+
+
+class ExampleAvroAnotherExample(TypedDict):
+    id: str
 '''

--- a/tests/test_cases/no_optional_field_record.avsc
+++ b/tests/test_cases/no_optional_field_record.avsc
@@ -1,0 +1,11 @@
+{
+    "namespace": "example.avro",
+    "type": "record",
+    "name": "AnotherExample",
+    "fields": [
+        {
+            "name": "id",
+            "type": "string"
+        }
+    ]
+}


### PR DESCRIPTION
Changes:
 - Only add the `Optional` type when required. This will make `flake8` happy when it checks that all imports are used.
 - Sort `Optional` and `TypedDict`.

Tested by publishing a dev version and using it in `avro-messages`.