### PR TITLE
Support schema refs by file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.10.0
+### Changed
+- Added the ability to provide schema references by their file names.  Usefull when the
+- schema types don't match the file names and fastavro can't automatically load them.
+  
 ## 0.9.0
 ### Changed
 - Added array type support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## 0.10.0
 ### Changed
-- Added the ability to provide schema references by their file names.  Usefull when the
+- Added the ability to provide schema references by their file names.  Useful when the
 - schema types don't match the file names and fastavro can't automatically load them.
   
 ## 0.9.0

--- a/avro_to_python_types/__init__.py
+++ b/avro_to_python_types/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 from .typed_dict_from_schema import (
     typed_dict_from_schema_file,
     typed_dict_from_schema_string,

--- a/avro_to_python_types/constants.py
+++ b/avro_to_python_types/constants.py
@@ -7,3 +7,4 @@ OPTIONAL = "Optional"
 SYMBOLS = "symbols"
 TYPE = "type"
 ITEMS = "items"
+LIST = 'List'

--- a/avro_to_python_types/constants.py
+++ b/avro_to_python_types/constants.py
@@ -7,4 +7,4 @@ OPTIONAL = "Optional"
 SYMBOLS = "symbols"
 TYPE = "type"
 ITEMS = "items"
-LIST = 'List'
+LIST = "List"

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -23,6 +23,7 @@ from avro_to_python_types.constants import (
     SYMBOLS,
     TYPE,
     ITEMS,
+    LIST,
 )
 
 
@@ -271,9 +272,9 @@ def types_for_schema(schema):
                         )
                         body.append(nested.tree)
                         if is_nullable(field):
-                            our_type.add_optional_element(name, f"list({nested.name})")
+                            our_type.add_optional_element(name, f"List[{nested.name}]")
                         else:
-                            our_type.add_required_element(name, f"list({nested.name})")
+                            our_type.add_required_element(name, f"List[{nested.name}]")
                         complex_types.append(nested.name)
                     else:
                         """Array is of a prmitive type"""
@@ -290,9 +291,9 @@ def types_for_schema(schema):
                         else:
                             array_type = prim_to_type[items_type]
                         if is_nullable(field):
-                            our_type.add_optional_element(name, f"list({array_type})")
+                            our_type.add_optional_element(name, f"List[{array_type}]")
                         else:
-                            our_type.add_required_element(name, f"list({array_type})")
+                            our_type.add_required_element(name, f"List[{array_type}]")
                 # primitive
                 else:
                     """Ths section process a primitive type or a named complex type."""
@@ -336,6 +337,8 @@ def types_for_schema(schema):
     # import the Optional type only if required
     if OPTIONAL in ast.dump(main_type.tree):
         additional_types.append(OPTIONAL)
+    if LIST in ast.dump(main_type.tree):
+        additional_types.append(LIST)
     additional_types.append("TypedDict")
     additional_types_as_str = ", ".join(additional_types)
 

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -267,7 +267,8 @@ def types_for_schema(schema):
                 else:
                     if isinstance(field[TYPE],list):
                         for fld in field[TYPE]:
-                            field_type = fld if fld != NULL else None
+                            if fld != NULL:
+                                field_type = fld 
                     else:
                         field_type = get_type(field[TYPE])
                     if not field_type in prim_to_type.keys():

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -143,8 +143,8 @@ def get_logical_type(types):
     raise ValueError(f"unexpected error in logical type: {types}")
 
 
-def resolve_enum_str(enums: list):
-    return "\n\n".join(enums) if len(enums) > 0 else ""
+def resolve_enum_str(enums: dict):
+    return "\n\n".join(enums.values()) if len(enums) > 0 else ""
 
 
 def _dedupe_ast(tree):
@@ -249,10 +249,11 @@ def types_for_schema(schema):
                         for word in get_enum_class(field[TYPE]).split(".")
                     )
                     enum_class = f"class {enum_class_name}(Enum):\n"
-                    for e in get_enum_symbols(field[TYPE]):
-                        enum_class += f"    {e} = '{e}'\n"
-                    enum_class += "\n\n"
-                    enums.append(enum_class)
+                    if not enum_class in enums.keys():
+                        for e in get_enum_symbols(field[TYPE]):
+                            enum_class += f"    {e} = '{e}'\n"
+                        enum_class += "\n\n"
+                        enums[enum_class] = enum_class
                     if is_nullable(field):
                         our_type.add_optional_element(name, enum_class_name)
                     else:
@@ -327,7 +328,7 @@ def types_for_schema(schema):
         return our_type
 
     imports = []
-    enums = []
+    enums = {}
     complex_types = []
     main_type = type_for_schema_record(schema, imports, enums, complex_types)
 

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -3,11 +3,11 @@ from .generate_typed_dict import GenerateTypedDict
 from .schema_mapping import prim_to_type, logical_to_python_type
 from enum import Enum
 from fastavro.schema import (
-    load_schema,
     expand_schema,
-    parse_schema,
-    load_schema_ordered,
     fullname,
+    load_schema,
+    load_schema_ordered,
+    parse_schema,
 )
 import ast
 import astunparse
@@ -196,7 +196,7 @@ def types_for_schema(schema):
                     field[TYPE], AvroSubType.RECORD.value
                 ) and isinstance(field[TYPE], list):
                     """union with complex type - This section processes the type from a
-                    union contining an expanded type, recursively.  Fastavro will expand
+                    union containing an expanded type, recursively.  Fastavro will expand
                     the types for the union the first time it encounters them and use a
                     reference thereafter.  So the first time it will be prcessed here and
                     subsequently in the primitives section.

--- a/avro_to_python_types/typed_dict_from_schema.py
+++ b/avro_to_python_types/typed_dict_from_schema.py
@@ -173,8 +173,8 @@ def _dedupe_ast(tree):
 def types_for_schema(schema):
     """
     This is the main function for the module.  It will parse a schema and return a
-    concrete type which extends the TypedDict class.  It currently supports most 
-    primitive, logical, union and array types.  It does not support microsecond 
+    concrete type which extends the TypedDict class.  It currently supports most
+    primitive, logical, union and array types.  It does not support microsecond
     precision time types and durations.
     """
     body = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "avro-to-python-types"
-version = "0.9.0"
+version = "0.10.0"
 description = "A library for converting avro schemas to python types."
 readme = "README.md"
 authors = ["Dan Green-Leipciger"]

--- a/tests/snapshots/snap_test_schema_to_typed_dict.py
+++ b/tests/snapshots/snap_test_schema_to_typed_dict.py
@@ -376,6 +376,39 @@ class DomainParent(TypedDict, total=False):
     favorite_color: Optional[str]
 '''
 
+snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_schema_references com.wave.Order.avsc'] = '''from enum import Enum
+from typing import TypedDict
+
+
+class ComWaveProduct_status(Enum):
+    AVAILABLE = "AVAILABLE"
+    OUT_OF_STOCK = "OUT_OF_STOCK"
+    ONLY_FEW_LEFT = "ONLY_FEW_LEFT"
+
+
+class ComWaveProduct(TypedDict, total=False):
+    product_id: int
+    product_name: str
+    product_description: Optional[str]
+    product_status: ComWaveProduct_status
+    product_category: list(str)
+    price: float
+    product_hash: str
+
+
+class ComWaveOrderDetail(TypedDict, total=False):
+    quantity: int
+    total: float
+    product_detail: ComWaveProduct
+
+
+class ComWaveOrder(TypedDict, total=False):
+    order_id: int
+    customer_id: int
+    total: float
+    order_details: list(ComWaveOrderDetail)
+'''
+
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_record.avsc'] = '''from typing import Optional, TypedDict
 
 

--- a/tests/snapshots/snap_test_schema_to_typed_dict.py
+++ b/tests/snapshots/snap_test_schema_to_typed_dict.py
@@ -8,7 +8,7 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots['SnapshotTypedDictArrayFromSchemaFile::test_array_map_schemas com.wave.Order.avsc'] = '''from enum import Enum
-from typing import List, TypedDict
+from typing import Optional, List, TypedDict
 
 
 class ComWaveProduct_status(Enum):
@@ -41,7 +41,7 @@ class ComWaveOrder(TypedDict, total=False):
 '''
 
 snapshots['SnapshotTypedDictArrayFromSchemaFile::test_array_map_schemas com.wave.OrderDetail.avsc'] = '''from enum import Enum
-from typing import TypedDict
+from typing import Optional, List, TypedDict
 
 
 class ComWaveProduct_status(Enum):
@@ -188,7 +188,7 @@ class DomainParent(TypedDict, total=False):
 '''
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_schema_references com.wave.Order.avsc'] = '''from enum import Enum
-from typing import List, TypedDict
+from typing import Optional, List, TypedDict
 
 
 class ComWaveProduct_status(Enum):

--- a/tests/snapshots/snap_test_schema_to_typed_dict.py
+++ b/tests/snapshots/snap_test_schema_to_typed_dict.py
@@ -8,7 +8,7 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots['SnapshotTypedDictArrayFromSchemaFile::test_array_map_schemas com.wave.Order.avsc'] = '''from enum import Enum
-from typing import TypedDict
+from typing import List, TypedDict
 
 
 class ComWaveProduct_status(Enum):
@@ -22,7 +22,7 @@ class ComWaveProduct(TypedDict, total=False):
     product_name: str
     product_description: Optional[str]
     product_status: ComWaveProduct_status
-    product_category: list(str)
+    product_category: List[str]
     price: float
     product_hash: str
 
@@ -37,7 +37,7 @@ class ComWaveOrder(TypedDict, total=False):
     order_id: int
     customer_id: int
     total: float
-    order_details: list(ComWaveOrderDetail)
+    order_details: List[ComWaveOrderDetail]
 '''
 
 snapshots['SnapshotTypedDictArrayFromSchemaFile::test_array_map_schemas com.wave.OrderDetail.avsc'] = '''from enum import Enum
@@ -55,7 +55,7 @@ class ComWaveProduct(TypedDict, total=False):
     product_name: str
     product_description: Optional[str]
     product_status: ComWaveProduct_status
-    product_category: list(str)
+    product_category: List[str]
     price: float
     product_hash: str
 
@@ -67,7 +67,7 @@ class ComWaveOrderDetail(TypedDict, total=False):
 '''
 
 snapshots['SnapshotTypedDictArrayFromSchemaFile::test_array_map_schemas com.wave.Product.avsc'] = '''from enum import Enum
-from typing import Optional, TypedDict
+from typing import Optional, List, TypedDict
 
 
 class ComWaveProduct_status(Enum):
@@ -81,198 +81,9 @@ class ComWaveProduct(TypedDict, total=False):
     product_name: str
     product_description: Optional[str]
     product_status: ComWaveProduct_status
-    product_category: list(str)
+    product_category: List[str]
     price: float
     product_hash: str
-'''
-
-snapshots['SnapshotTypedDictArrayFromSchemaFile::test_array_map_schemas wave_arraytype.avsc'] = '''from typing import Optional, TypedDict
-
-
-class WavePytestArrayUser(TypedDict, total=False):
-    name: str
-    favorite_number: Optional[int]
-    favorite_color: Optional[str]
-'''
-
-snapshots['SnapshotTypedDictArrayMapFromSchemaFile::test_array_map_schemas com.wave.Order.avsc'] = '''from typing import TypedDict
-
-
-class ComWaveOrder(TypedDict, total=False):
-    order_id: int
-    customer_id: int
-    total: float
-    order_details: array
-'''
-
-snapshots['SnapshotTypedDictFromOrder::test_snapshot_expandable_schemas common.ChildA.avsc'] = '''from typing import Optional, TypedDict
-
-
-class CommonChildA(TypedDict, total=False):
-    name: str
-    favorite_number: Optional[int]
-    favorite_color: Optional[str]
-'''
-
-snapshots['SnapshotTypedDictFromOrder::test_snapshot_expandable_schemas common.ChildB.avsc'] = '''from datetime import date
-from datetime import datetime
-from datetime import time
-from decimal import Decimal
-from typing import TypedDict
-from uuid import UUID
-
-
-class CommonChildB(TypedDict, total=False):
-    streetaddress: str
-    city: str
-    birthdate: date
-    appt_date: date
-    time_of_day_birth: time
-    timestamp_of_birth: datetime
-    uuid_of_birth_record: UUID
-    weight: Decimal
-'''
-
-snapshots['SnapshotTypedDictFromOrder::test_snapshot_expandable_schemas common.ChildC.avsc'] = '''from datetime import date
-from datetime import datetime
-from datetime import time
-from decimal import Decimal
-from enum import Enum
-from typing import Optional, TypedDict
-from uuid import UUID
-
-
-class CommonSchool(Enum):
-    StBonifice = "StBonifice"
-    HogWarts = "HogWarts"
-    HardKnocks = "HardKnocks"
-    UnseenUniversity = "UnseenUniversity"
-
-
-class CommonEyeColor(Enum):
-    green = "green"
-    brown = "brown"
-    blue = "blue"
-
-
-class CommonChildC(TypedDict, total=False):
-    streetaddress: Optional[str]
-    city: Optional[str]
-    birthdate: date
-    appt_date: date
-    time_of_day_birth: Optional[time]
-    timestamp_of_birth: datetime
-    uuid_of_birth_record: UUID
-    weight: Decimal
-    timestamp_of_first_checkup: Optional[datetime]
-    school: CommonSchool
-    eye_color: Optional[CommonEyeColor]
-'''
-
-snapshots['SnapshotTypedDictFromOrder::test_snapshot_expandable_schemas domain.Parent.avsc'] = '''from datetime import date
-from datetime import datetime
-from datetime import time
-from decimal import Decimal
-from typing import Optional, TypedDict
-from uuid import UUID
-
-
-class CommonChildA(TypedDict, total=False):
-    name: str
-    favorite_number: Optional[int]
-    favorite_color: Optional[str]
-
-
-class CommonChildB(TypedDict, total=False):
-    streetaddress: str
-    city: str
-    birthdate: date
-    appt_date: date
-    time_of_day_birth: time
-    timestamp_of_birth: datetime
-    uuid_of_birth_record: UUID
-    weight: Decimal
-
-
-class DomainCompositeItem(TypedDict, total=False):
-    composite_a: CommonChildA
-    composite_b: CommonChildB
-
-
-class DomainParent(TypedDict, total=False):
-    first_item: CommonChildA
-    second_item: CommonChildA
-    composite_item: DomainCompositeItem
-    favorite_color: Optional[str]
-'''
-
-snapshots['SnapshotTypedDictFromOrder::test_snapshot_self_contained_schemas nested_record.avsc'] = '''from typing import Optional, TypedDict
-
-
-class ExampleAvroAddressUSRecord(TypedDict, total=False):
-    streetaddress: str
-    city: str
-
-
-class ExampleAvroUser(TypedDict, total=False):
-    name: str
-    favorite_number: Optional[int]
-    favorite_color: Optional[str]
-    address: ExampleAvroAddressUSRecord
-'''
-
-snapshots['SnapshotTypedDictFromOrder::test_snapshot_self_contained_schemas nested_records.avsc'] = '''from typing import Optional, TypedDict
-
-
-class ExampleAddressUSRecord(TypedDict, total=False):
-    streetaddress: str
-    city: str
-
-
-class ExampleOtherThing(TypedDict, total=False):
-    thing1: str
-    thing2: Optional[int]
-
-
-class ExampleUser(TypedDict, total=False):
-    name: str
-    favorite_number: Optional[int]
-    favorite_color: Optional[str]
-    address: ExampleAddressUSRecord
-    other_thing: ExampleOtherThing
-'''
-
-snapshots['SnapshotTypedDictFromOrder::test_snapshot_self_contained_schemas nested_records_deep.avsc'] = '''from typing import Optional, TypedDict
-
-
-class ExampleAvroAddressUSRecord(TypedDict, total=False):
-    streetaddress: str
-    city: str
-
-
-class ExampleAvroNextOtherThing(TypedDict, total=False):
-    thing1: str
-    thing2: Optional[int]
-
-
-class ExampleAvroOtherThing(TypedDict, total=False):
-    thing1: str
-    other_thing: ExampleAvroNextOtherThing
-
-
-class ExampleAvroUser(TypedDict, total=False):
-    name: str
-    favorite_number: Optional[int]
-    favorite_color: Optional[str]
-    address: ExampleAvroAddressUSRecord
-    other_thing: ExampleAvroOtherThing
-'''
-
-snapshots['SnapshotTypedDictFromOrder::test_snapshot_self_contained_schemas no_optional_field_record.avsc'] = '''from typing import TypedDict
-
-
-class ExampleAvroAnotherExample(TypedDict, total=False):
-    id: str
 '''
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_expandable_schemas common.ChildA.avsc'] = '''from typing import Optional, TypedDict
@@ -377,7 +188,7 @@ class DomainParent(TypedDict, total=False):
 '''
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_schema_references com.wave.Order.avsc'] = '''from enum import Enum
-from typing import TypedDict
+from typing import List, TypedDict
 
 
 class ComWaveProduct_status(Enum):
@@ -391,7 +202,7 @@ class ComWaveProduct(TypedDict, total=False):
     product_name: str
     product_description: Optional[str]
     product_status: ComWaveProduct_status
-    product_category: list(str)
+    product_category: List[str]
     price: float
     product_hash: str
 
@@ -406,7 +217,7 @@ class ComWaveOrder(TypedDict, total=False):
     order_id: int
     customer_id: int
     total: float
-    order_details: list(ComWaveOrderDetail)
+    order_details: List[ComWaveOrderDetail]
 '''
 
 snapshots['SnapshotTypedDictFromSchemaFile::test_snapshot_self_contained_schemas nested_record.avsc'] = '''from typing import Optional, TypedDict

--- a/tests/test_schema_to_typed_dict.py
+++ b/tests/test_schema_to_typed_dict.py
@@ -23,11 +23,12 @@ class SnapshotTypedDictFromSchemaFile(snapshottest.TestCase):
             schema_name = test_schema_file.rsplit("/", 1)[-1]
             self.assertMatchSnapshot(test_output, schema_name)
 
-
     def test_snapshot_schema_references(self):
-        references = ["tests/test_shopping_cart/com.wave.Product.avsc",
-                "tests/test_shopping_cart/com.wave.OrderDetail.avsc"]
-        test_schema_file = "tests/test_shopping_cart/com.wave.Order.avsc";
+        references = [
+            "tests/test_shopping_cart/com.wave.Product.avsc",
+            "tests/test_shopping_cart/com.wave.OrderDetail.avsc",
+        ]
+        test_schema_file = "tests/test_shopping_cart/com.wave.Order.avsc"
         test_output = typed_dict_from_schema_file(test_schema_file, references)
         schema_name = test_schema_file.rsplit("/", 1)[-1]
         self.assertMatchSnapshot(test_output, schema_name)

--- a/tests/test_schema_to_typed_dict.py
+++ b/tests/test_schema_to_typed_dict.py
@@ -24,6 +24,15 @@ class SnapshotTypedDictFromSchemaFile(snapshottest.TestCase):
             self.assertMatchSnapshot(test_output, schema_name)
 
 
+    def test_snapshot_schema_references(self):
+        references = ["tests/test_shopping_cart/com.wave.Product.avsc",
+                "tests/test_shopping_cart/com.wave.OrderDetail.avsc"]
+        test_schema_file = "tests/test_shopping_cart/com.wave.Order.avsc";
+        test_output = typed_dict_from_schema_file(test_schema_file, references)
+        schema_name = test_schema_file.rsplit("/", 1)[-1]
+        self.assertMatchSnapshot(test_output, schema_name)
+
+
 class SnapshotTypedDictArrayFromSchemaFile(snapshottest.TestCase):
     def test_array_map_schemas(self):
         for test_schema_file in shopping_cart_files:


### PR DESCRIPTION
## Description
When this module was invoked with a schema who's references were in files that don't conform to the avro file naming schema it could not validate them.  Added the ability to provide an optional list of reference files.
Also improved the processing of unions where the union type was not a full type but a reference to a previously processed type.  Fastavro does not expand schema types a second time, but uses a reference instead.  

Note:  we have decided to change the names of schema files in avro-messages so some of this pr is not strictly necessary but does improve the overall utility of the interface.

## Checklist for schema change PRs

- [x] Version bumped in `pyproject.toml`, `avro_to_python_types/__init__.py` and `CHANGELOG.md`

